### PR TITLE
feat: Add Zenn article integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ CONTACT_FORM_ENDPOINT=https://ssgform.com/s/xxxxx
 # Qiita Settings
 QIITA_API_ENDPOINT=https://qiita.com/api/v2
 QIITA_USERNAME=USER_NAME
+
+# Zenn Settings
+ZENN_API_ENDPOINT=https://zenn.dev/api
+ZENN_USERNAME=saku2323

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ npm run format:check # 変更なしでフォーマットチェック
 2. **外部コンテンツ統合**
 
    - Qiita API統合（`src/lib/api-clients/qiita.ts`）
+   - Zenn API統合（`src/lib/api-clients/zenn.ts`）
    - メモリキャッシュ（1時間TTL）による API レスポンス最適化
    - OGP画像の自動取得とサムネイル生成
 
@@ -101,6 +102,10 @@ PUBLIC_CONTACT_FORM_ENDPOINT=https://ssgform.com/s/xxxxx
 # オプション: Qiita統合用
 QIITA_API_ENDPOINT=https://qiita.com/api/v2
 QIITA_USERNAME=USER_NAME
+
+# オプション: Zenn統合用
+ZENN_API_ENDPOINT=https://zenn.dev/api
+ZENN_USERNAME=saku2323
 
 # オプション: アナリティクス用
 PUBLIC_GOOGLE_ANALYTICS_ID=GA_TRACKING_ID

--- a/src/lib/api-clients/zenn.ts
+++ b/src/lib/api-clients/zenn.ts
@@ -1,0 +1,98 @@
+import { type ExternalPost } from '../../types/index';
+import { getOGPImage } from '../utils/ogp';
+
+const CACHE_DURATION = 60 * 60 * 1000; // 1時間
+const cache = new Map<string, { data: ExternalPost[]; timestamp: number }>();
+
+interface ZennArticle {
+  id: number;
+  title: string;
+  slug: string;
+  published_at: string;
+  path: string;
+  user: {
+    username: string;
+    name: string;
+    avatar_small_url: string;
+  };
+  topics: Array<{
+    name: string;
+    display_name: string;
+  }>;
+  emoji: string;
+  article_type: 'tech' | 'idea';
+}
+
+interface ZennResponse {
+  articles: ZennArticle[];
+  next_page: string | null;
+}
+
+function parseDate(dateStr: string): Date {
+  try {
+    const date = new Date(dateStr);
+    return isNaN(date.getTime()) ? new Date() : date;
+  } catch {
+    return new Date();
+  }
+}
+
+export async function getZennPosts(username?: string): Promise<ExternalPost[]> {
+  const targetUsername = username || process.env.ZENN_USERNAME;
+  if (!targetUsername) {
+    throw new Error('Zenn username is not provided');
+  }
+
+  const cacheKey = `zenn-posts-${targetUsername}`;
+  const cachedData = cache.get(cacheKey);
+  const now = Date.now();
+
+  if (cachedData && now - cachedData.timestamp < CACHE_DURATION) {
+    return cachedData.data;
+  }
+
+  try {
+    const baseUrl = process.env.ZENN_API_ENDPOINT || 'https://zenn.dev/api';
+    const response = await fetch(`${baseUrl}/articles?username=${targetUsername}&order=latest`, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch Zenn posts');
+    }
+
+    const data: ZennResponse = await response.json();
+
+    const posts = await Promise.all(
+      data.articles.map(async (article) => {
+        const articleUrl = `https://zenn.dev${article.path}`;
+        return {
+          title: article.title,
+          url: articleUrl,
+          platform: 'Zenn',
+          publishDate: parseDate(article.published_at),
+          thumbnail: await getOGPImage(articleUrl),
+          isExternal: true as const,
+          tags: article.topics.map((topic) => topic.display_name),
+        };
+      })
+    );
+
+    cache.set(cacheKey, {
+      data: posts,
+      timestamp: now,
+    });
+
+    return posts;
+  } catch (error) {
+    console.error('Failed to fetch Zenn posts:', error);
+
+    if (cachedData) {
+      return cachedData.data;
+    }
+
+    return [];
+  }
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -4,9 +4,11 @@ import Layout from '../../layouts/Layout.astro';
 import { BlogControls } from '../../components/Blog';
 import HeroSection from '../../components/Hero/HeroSection.astro';
 import { getQiitaPosts } from '../../lib/api-clients/qiita';
+import { getZennPosts } from '../../lib/api-clients/zenn';
 
 const posts = await getCollection('blog');
 const qiitaPosts = await getQiitaPosts('ngtnysk');
+const zennPosts = await getZennPosts('saku2323');
 
 const allPosts = [
   ...posts.map((post) => ({
@@ -20,6 +22,7 @@ const allPosts = [
     tags: post.data.tags || [],
   })),
   ...qiitaPosts,
+  ...zennPosts,
 ];
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,9 +5,11 @@ import HeroSection from '../components/Hero/HeroSection.astro';
 import { PostCard } from '../components/Blog/PostCard';
 import SectionHeading from '../components/Section/SectionHeading.astro';
 import { getQiitaPosts } from '../lib/api-clients/qiita';
+import { getZennPosts } from '../lib/api-clients/zenn';
 
 const posts = await getCollection('blog');
 const qiitaPosts = await getQiitaPosts('ngtnysk');
+const zennPosts = await getZennPosts('saku2323');
 
 const allPosts = [
   ...posts.map((post) => ({
@@ -21,6 +23,7 @@ const allPosts = [
     platform: '',
   })),
   ...qiitaPosts,
+  ...zennPosts,
 ].sort((a, b) => b.publishDate.getTime() - a.publishDate.getTime());
 
 const POSTS_PER_SECTION = 4;


### PR DESCRIPTION
Add Zenn article integration to fetch and display articles from https://zenn.dev/saku2323 alongside existing Qiita articles.

## Changes
- Add Zenn API client following Qiita pattern
- Update blog pages to include Zenn articles
- Add configuration documentation
- Include 1-hour caching and OGP image extraction

Closes #5

Generated with [Claude Code](https://claude.ai/code)