### PR TITLE
chore: 公開前の環境変数ガイドを整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,21 @@
 # API Endpoints
-PUBLIC_CONTACT_FORM_ENDPOINT=https://ssgform.com/s/xxxxx
+# SSGFormで発行されたエンドポイントURL（例: https://ssgform.com/s/your-form-id）
+PUBLIC_CONTACT_FORM_ENDPOINT=
 
 # Qiita Settings
 QIITA_API_ENDPOINT=https://qiita.com/api/v2
-QIITA_USERNAME=USER_NAME
+# 公開プロフィールと連動させたい場合はご自身のユーザー名を設定
+QIITA_USERNAME=
 
 # Zenn Settings
 ZENN_API_ENDPOINT=https://zenn.dev/api
-ZENN_USERNAME=saku2323
+# 公開プロフィールと連動させたい場合はご自身のユーザー名を設定
+ZENN_USERNAME=
 
 # Google Analytics
+# 計測に使用するMeasurement ID（例: G-XXXXXXXXXX）
 PUBLIC_GOOGLE_ANALYTICS_ID=
 
 # Google reCAPTCHA
+# reCAPTCHA v2のサイトキー（公開可能なキー）
 PUBLIC_GOOGLE_RECAPTCHA_SITE_KEY=

--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ git clone [repository-url]
 npm install
 ```
 
-3. 開発サーバーを起動：
+3. 環境変数ファイルを作成：
+
+```bash
+cp .env.example .env
+# 各サービスのIDやエンドポイントを編集
+```
+
+4. 開発サーバーを起動：
 
 ```bash
 npm run dev
@@ -69,6 +76,8 @@ npm run dev
 ## 🔄 自動更新
 
 環境構成の詳細は `environment.md` に記載されており、プロジェクトの構造が変更されると自動的に更新されます。
+
+公開リポジトリ向けの環境変数設定とセキュリティチェックは `docs/public-release-checklist.md` を参照してください。
 
 ## 📄 ライセンス
 

--- a/docs/public-release-checklist.md
+++ b/docs/public-release-checklist.md
@@ -1,0 +1,29 @@
+# 公開リポジトリ移行チェックリスト
+
+パブリック化に伴う環境変数の再投入と動作確認フローをまとめています。Cloudflare Pages や Vercel など、デプロイ環境に合わせて調整してください。
+
+## 1. ローカル環境の `.env`
+
+1. `.env.example` をコピーして `.env` を再作成する。
+2. 以下の値を最新の本番向けクレデンシャルに置き換える。
+   - `PUBLIC_CONTACT_FORM_ENDPOINT`
+   - `PUBLIC_GOOGLE_ANALYTICS_ID`
+   - `PUBLIC_GOOGLE_RECAPTCHA_SITE_KEY`
+   - Qiita / Zenn のユーザー名（任意）
+3. `npm run dev` で起動し、フォーム送信やダークモード切替など主要機能を確認する。
+
+## 2. デプロイ環境のシークレット設定
+
+- Cloudflare Pages を利用する場合、プロジェクト設定の環境変数セクションに上記キーを登録する。
+- Google Analytics など第三者サービスでローテーションを実施した際は、同じ手順で最新値へ更新する。
+- 値の変更後は `npm run build` → `npm run preview` をローカルで実行し、エラーがないことを確認してからデプロイする。
+
+## 3. 秘匿情報の流出チェック
+
+- `trufflehog --json --regex --entropy False .` を実行し、履歴に秘密情報が残っていないかを定期的に確認する。
+- クラウドログや Cloudflare KV など外部サービス側の設定も併せて見直し、不要なキーは削除する。
+
+## 4. 公開後の運用メモ
+
+- Issue/Discussions で問い合わせを受け付ける場合は、README などに窓口を明記する。
+- 追加で機密値を扱う機能を導入した場合は、`.env.example` とこのチェックリストを必ず更新する。

--- a/src/lib/api-clients/contact.ts
+++ b/src/lib/api-clients/contact.ts
@@ -1,33 +1,34 @@
 import { type ContactForm } from '../../types/index';
 
 // SSGFormのエンドポイントURL
-// クライアントサイドでも使えるようにpublicなエンドポイントです
-const FORM_ENDPOINT =
-  import.meta.env.PUBLIC_CONTACT_FORM_ENDPOINT || 'https://ssgform.com/s/rGYtwI020c3g';
+// 必ず環境変数で設定し、ハードコードされたURLが残らないようにする
+const resolveEndpoint = () => {
+  const endpoint = import.meta.env.PUBLIC_CONTACT_FORM_ENDPOINT?.trim();
+  if (!endpoint) {
+    throw new Error('Missing PUBLIC_CONTACT_FORM_ENDPOINT');
+  }
+  return endpoint;
+};
 
 export async function submitContactForm(data: ContactForm): Promise<Response> {
-  try {
-    // FormDataを生成
-    const formData = new FormData();
+  // FormDataを生成
+  const formData = new FormData();
 
-    // 各フィールドをFormDataに追加
-    Object.entries(data).forEach(([key, value]) => {
-      formData.append(key, String(value));
-    });
+  // 各フィールドをFormDataに追加
+  Object.entries(data).forEach(([key, value]) => {
+    formData.append(key, String(value));
+  });
 
-    // FormDataを使って送信(Content-Typeヘッダーは自動的に設定される)
-    const response = await fetch(FORM_ENDPOINT, {
-      method: 'POST',
-      body: formData,
-    });
+  // FormDataを使って送信(Content-Typeヘッダーは自動的に設定される)
+  const response = await fetch(resolveEndpoint(), {
+    method: 'POST',
+    body: formData,
+  });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Failed to submit contact form: ${response.status} ${errorText}`);
-    }
-
-    return response;
-  } catch (error) {
-    throw error;
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to submit contact form: ${response.status} ${errorText}`);
   }
+
+  return response;
 }


### PR DESCRIPTION
## Summary
-  の値をプレースホルダー化し、公開時の入力ガイドを追記
- フォーム送信APIのハードコードURLを削除し、環境変数必須化
- 公開前チェックリストを追加し README から参照
- trufflehog で履歴スキャンを実施し秘匿情報の残存がないことを確認

## Testing
- [ ] npm run lint
- [ ] npm run astro check

Closes #13