### PR TITLE
refactor: ブログ記事サムネイルのアスペクト比を調整

### DIFF
--- a/src/components/Blog/PostCard.tsx
+++ b/src/components/Blog/PostCard.tsx
@@ -1,8 +1,8 @@
 import type { Post } from '../../types/index';
 
 type PostCardProps = Post & {
-  showTags?: boolean; // タグの表示/非表示を制御するためのプロパティを追加
-  index?: number; // 画像の読み込み優先度を決定するためのインデックス
+  showTags?: boolean;
+  index?: number;
 };
 
 // PostCardコンポーネント固有のスタイル
@@ -10,12 +10,12 @@ const postCardStyles = {
   article:
     'bg-white dark:bg-gray-900 rounded-md overflow-hidden transition-all duration-200 h-full hover',
   link: 'block',
-  imageContainer: 'relative aspect-video overflow-hidden', // overflow-hiddenを維持
-  image: 'w-full h-full object-cover transition-all duration-300 ease-in-out', // 拡大を削除
+  imageContainer: 'relative aspect-thumnail overflow-hidden',
+  image: 'w-full h-full object-cover transition-all duration-300 ease-in-out',
   overlay:
-    'absolute inset-0 bg-black bg-opacity-0 flex items-center justify-center transition-all duration-300 ease-in-out lg:group-hover:bg-opacity-60', // オーバーレイを追加
+    'absolute inset-0 bg-black bg-opacity-0 flex items-center justify-center transition-all duration-300 ease-in-out lg:group-hover:bg-opacity-60',
   readText:
-    'text-white font-bold opacity-0 transform translate-y-4 transition-all duration-300 ease-in-out lg:group-hover:opacity-100 lg:group-hover:translate-y-0 tracking-wider', // 「記事を読む」テキスト
+    'text-white font-bold opacity-0 transform translate-y-4 transition-all duration-300 ease-in-out lg:group-hover:opacity-100 lg:group-hover:translate-y-0 tracking-wider',
   contentContainer: 'p-4',
   title: 'text-md font-semibold text-gray-900 dark:text-white line-clamp-4 leading-tight',
   date: 'text-sm text-gray-600 dark:text-gray-400',
@@ -45,7 +45,7 @@ export function PostCard({
     <article className={postCardStyles.article}>
       <a
         href={url}
-        className={`${postCardStyles.link} group`} // groupクラスを追加
+        className={`${postCardStyles.link} group`}
         target={isExternal ? '_blank' : '_self'}
         rel={isExternal ? 'noopener noreferrer' : ''}
       >

--- a/uno.config.ts
+++ b/uno.config.ts
@@ -109,6 +109,9 @@ export default defineConfig({
     'blog-post-grid': 'grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
     'blog-load-more-button':
       'mx-auto mt-8 px-6 py-2 bg-gray-800 text-white rounded-md lg:hover:opacity-70 transition-all duration-300 dark:bg-gray-200 dark:text-gray-800 font-bold',
+
+    // アスペクト比
+    'aspect-thumnail': 'aspect-[15/8]',
   },
   rules: [],
 });


### PR DESCRIPTION
## 概要

ブログカードコンポーネントのサムネイル画像のアスペクト比を16:9から15:8に変更し、より視認性の高いレイアウトを実現しました。

## 変更内容

- **PostCard.tsx**: サムネイルのアスペクト比を`aspect-video`（16:9）から`aspect-thumnail`（15:8）に変更
- **uno.config.ts**: 新しいショートカット`aspect-thumnail`（aspect-[15/8]）を追加
- **package.json**: プロジェクト説明を"個人ブログサイト"から"個人ブログ＆ポートフォリオウェブサイト"に更新
- コードクリーンアップ: 不要なコメントを削除

## 動作確認

- [x] ビルドの確認（`npm run build`）
- [x] 開発サーバーでの表示確認（`npm run dev`）
- [x] レスポンシブ表示の確認（モバイル/タブレット/デスクトップ）
- [x] OGP画像生成の確認（`npm run build:with-ogp`）

## 関連Issue

Closes #

## レビュー観点

- サムネイル画像の15:8アスペクト比が、デザイン的に適切か
- レスポンシブ対応（sm、lg）での表示崩れがないか
- 画像の切り抜きによる情報欠落がないか

## スクリーンショット

<!-- デスクトップ/モバイルでのビフォー・アフター画像を添付してください -->