### PR TITLE
Add theme-color meta tags for light and dark color schemes

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -65,6 +65,8 @@ const gaId = import.meta.env.PUBLIC_GOOGLE_ANALYTICS_ID;
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
     <meta content="email=no,telephone=no,address=no" name="format-detection" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f3f4f6" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1f2937" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />


### PR DESCRIPTION
### Motivation
- Ensure the browser UI (status bar / address bar) matches the site's light and dark themes by specifying appropriate theme colors for each color scheme.

### Description
- Add two `<meta name="theme-color">` tags with `media` attributes to `src/layouts/Layout.astro` to set `#f3f4f6` for light mode and `#1f2937` for dark mode.

### Testing
- Ran a local production build with `npm run build` and served the output with `npm run preview`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d20f3ac31c832baf32c4b4f9086dc2)