### PR TITLE
docs: clarify pnpm cache wording

### DIFF
--- a/src/content/blog/ja/learn-cachedir-astro.mdx
+++ b/src/content/blog/ja/learn-cachedir-astro.mdx
@@ -106,7 +106,7 @@ my-astro-project/
 
 ### `.pnpm/v11`
 - pnpmが依存パッケージを管理する内部ディレクトリの一部です。
-- Astro固有ではなく、pnpmがパッケージ解決や実体管理のために使う領域なのです。
+- Astro固有ではなく、pnpmがパッケージ解決や実体管理のために使う場所です。
 
 [^1]: `data-store.json`は、Content collectionsが読み込んだ記事やメタデータをAstro内部で扱いやすくするための保存先です。通常は開発者が直接編集するものではなく、元の`.md`や`.mdx`を編集します。
 [^2]: Content collectionsは、AstroでMarkdownやMDXなどのコンテンツを型安全に管理するための仕組みです。公式ドキュメント: [Content collections | Astro Docs](https://docs.astro.build/ja/guides/content-collections/)


### PR DESCRIPTION
### Motivation
- Improve clarity and tone of the Japanese explanation for the `.pnpm/v11` entry by using a more natural phrasing.

### Description
- Updated the sentence under `### .pnpm/v11` in `src/content/blog/ja/learn-cachedir-astro.mdx`, replacing 「領域なのです」 with 「場所です」.

### Testing
- Executed `git diff --check` and `git status --short` prior to committing, and both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a959fbcd8832ba262aaecf86398a5)